### PR TITLE
Fix systemd dependencies

### DIFF
--- a/etc/auksd.service.in
+++ b/etc/auksd.service.in
@@ -10,4 +10,4 @@ ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 
 [Install]
-WantedBy=auksdrenewer.service
+WantedBy=multi-user.target

--- a/etc/auksdrenewer.service.in
+++ b/etc/auksdrenewer.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Auks Credentials Renewer Daemon
 After=network.target
+Wants=aukspriv.service
 
 [Service]
 Type=simple

--- a/etc/aukspriv.service.in
+++ b/etc/aukspriv.service.in
@@ -9,4 +9,4 @@ ExecStart=@sbindir@/aukspriv $AUKSPRIV_OPTIONS
 GuessMainPID=true
 
 [Install]
-WantedBy=auksdrenewer.service
+WantedBy=multi-user.target


### PR DESCRIPTION
Aukspriv also has a standalone use case (for auks).
Aukspriv needs to be wanted by multi-user.target for systemd to start it (when enabled).