### PR TITLE
Update auks.c

### DIFF
--- a/src/auks/auks.c
+++ b/src/auks/auks.c
@@ -129,7 +129,7 @@ main(int argc,char** argv)
 \t-C ccache\tConfiguration file\n\
 \t-u uid\t\tuid of requested cred owner (get request only)\n\n";
 
-	char  option;
+	int  option;
   
 	auks_engine_t engine;
 


### PR DESCRIPTION
on arch where char is not signed (powerpc seems to be one) parsing options fails as 'option' will be 255 and not -1.