### PR TITLE
Enlarge AUKS_CRED_DATA_MAX_LENGTH to 4096

### DIFF
--- a/src/api/auks/auks_cred.h
+++ b/src/api/auks/auks_cred.h
@@ -84,7 +84,7 @@
 #define AUKS_CRED_INVALID_TIME       0
 #define AUKS_CRED_FILE_MAX_LENGTH  128
 
-#define AUKS_CRED_DATA_MAX_LENGTH 2048
+#define AUKS_CRED_DATA_MAX_LENGTH 4096
 
 typedef struct auks_cred_info {
 	char principal[AUKS_PRINCIPAL_MAX_LENGTH + 1];


### PR DESCRIPTION
Fix the "auks cred: input buffer is too large" (AUKS_ERROR_CRED_INIT_BUFFER_TOO_LARGE) error for tgt larger than 2048 (which is the case at multiple sites it seems).