### PR TITLE
fix #24 slurmstepd not killing auks process

### DIFF
--- a/src/plugins/slurm/slurm-spank-auks.c
+++ b/src/plugins/slurm/slurm-spank-auks.c
@@ -290,6 +290,9 @@ slurm_spank_user_init (spank_t sp, int ac, char **av)
 		xerror("unable to launch renewer process");
 	}
 	else if ( renewer_pid == 0 ) {
+		sigset_t mask;
+		sigemptyset(&mask);
+		sigprocmask(SIG_SETMASK, &mask, NULL);
 		char *argv[4];
 		argv[0]= BINDIR "/auks" ;
 		argv[1]="-R";argv[2]="loop";


### PR DESCRIPTION
reset sigmask to default for the new process -that will run auks-.
The inherited one  -from slurmstepd- ignores among other things SIGTERM