### PR TITLE
Patchset on krb5 ccache handling

### DIFF
--- a/src/api/auks/auks_krb5_cred.h
+++ b/src/api/auks/auks_krb5_cred.h
@@ -212,4 +212,35 @@ int auks_krb5_cred_renew_buffer(char *in_buf,size_t in_buf_len,
 int auks_krb5_cred_deladdr_buffer(char *in_buf,size_t in_buf_len,
 				  char** pout_buf,size_t *pout_buf_len);
 
+
+/*!
+ * \brief Generates a new unique ccache usique krb5_cc_new_unique
+ * \internal
+ *
+ * \param fullanme_out pointer on the newly created ccache.
+                       Caller's responsibility to free it.
+ *
+ * \retval AUKS_SUCCESS
+ * \retval AUKS_ERROR
+ * \retval AUKS_ERROR_KRB5_CRED_INIT_CTX
+ * \retval AUKS_ERROR_KRB5_CRED_OPEN_CC
+ *
+ */
+int auks_krb_cc_new_unique(char ** fullname_out);
+
+/*!
+ * \brief Destroys the given ccache
+ * \internal
+ *
+ * \param fullanme Name of the ccache to destroy
+ *
+ * \retval AUKS_SUCCESS
+ * \retval AUKS_ERROR
+ * \retval AUKS_ERROR_KRB5_CRED_INIT_CTX
+ * \retval AUKS_ERROR_KRB5_CRED_OPEN_CC
+ * \retval AUKS_ERROR_KRB5_CRED_READ_CC
+ *
+ */
+int auks_krb_cc_destroy(char * fullname);
+
 #endif

--- a/src/auksd/aukspriv
+++ b/src/auksd/aukspriv
@@ -22,9 +22,6 @@
 #                            default value is the first princ found in 
 #                            the keytab
 #
-#  AUKS_PRIV_CCACHE_APPEND : set the string to append to ccache pattern
-#                            default value is no string to append
-#
 #  AUKS_PRIV_LIFETIME      : set the credential lifetime in seconds
 #                            default value is 36000 (10h)
 #
@@ -203,34 +200,33 @@ if [[ -n ${AUKS_PRIV_USER} ]] && \
 
     while [ 1 -eq 1 ]
       do
-    
-      ccache="/tmp/krb5cc_$(id -u ${AUKS_PRIV_USER})${AUKS_PRIV_CCACHE_APPEND}"
+      if [[ ${AUKS_PRIV_USER} == "root" ]]; then
+	  # If we're targeting the root user, that's easy stuff.
+	  ERROR=$(${timeout_cmd} -s9 ${AUKS_PRIV_KINIT_TIMEOUT} ${kinit_cmd} -l ${AUKS_PRIV_LIFETIME} \
+	      -kt ${AUKS_PRIV_KEYTAB} ${AUKS_PRIV_PRINC} 2>&1 >/dev/null)
+	  ERR_CODE=$?
+      else
+	  # If we're not targetting the root user, we must change out identity.
+	  # To do that, we must make sure that the keytab is still reachable.
+	  # If not readable, fallback to the old behavior : use /tmp/ ccaches
+	  if ! su -c "test -r ${AUKS_PRIV_KEYTAB}" ${AUKS_PRIV_USER}; then
+	      fallback_ccache="/tmp/krb5_$(id -u ${AUKS_PRIV_USER})"
+	      ${LOGGER} "The keytab (${AUKS_PRIV_KEYTAB}) is not readable by the ${AUKS_PRIV_USER} user. \
+                         Using ${fallback_ccache} as the credential cache"
 
+	      ERROR=$(${timeout_cmd} -s9 ${AUKS_PRIV_KINIT_TIMEOUT} ${kinit_cmd} -l ${AUKS_PRIV_LIFETIME} -c ${fallback_ccache} \
+		  -kt ${AUKS_PRIV_KEYTAB} ${AUKS_PRIV_PRINC} 2>&1 >/dev/null)
+	      ERR_CODE=$?
+	      chown ${AUKS_PRIV_USER}: ${fallback_ccache}
+	      chown 0600 ${fallback_ccache}
+	  else
+	      ERROR=$(su -c "${timeout_cmd} -s9 ${AUKS_PRIV_KINIT_TIMEOUT} ${kinit_cmd} -l ${AUKS_PRIV_LIFETIME} \
+	      -kt ${AUKS_PRIV_KEYTAB} ${AUKS_PRIV_PRINC}" ${AUKS_PRIV_USER} 2>&1 >/dev/null)
+	      ERR_CODE=$?
+	  fi
 
-      touch ${ccache} 2>/dev/null
-      if [ $? -ne 0 ]
-	  then
-	  ${LOGGER} "unable to touch ccache"
-	  exit 1
       fi
-      
-      chmod 0600 ${ccache} 2>/dev/null
-      if [ $? -ne 0 ]
-	  then
-	  ${LOGGER} "unable to set ccache mode to 0600"
-	  exit 1
-      fi
-      
-      chown ${AUKS_PRIV_USER} ${ccache} 2>/dev/null
-      if [ $? -ne 0 ]
-	  then
-	  ${LOGGER} "unable to set ccache user to ${AUKS_PRIV_USER}"
-	  exit 1
-      fi
-      
-      ERROR=$(${timeout_cmd} -s9 ${AUKS_PRIV_KINIT_TIMEOUT} ${kinit_cmd} -l ${AUKS_PRIV_LIFETIME} -c ${ccache} \
-	  -kt ${AUKS_PRIV_KEYTAB} ${AUKS_PRIV_PRINC} 2>&1 >/dev/null)
-      if [ $? -ne 0 ]
+      if [ $ERR_CODE -ne 0 ]
 	  then
 	  ${LOGGER} "unable to get ccache for ${AUKS_PRIV_PRINC} using \
 	      ktfile ${AUKS_PRIV_KEYTAB} : ${ERROR}"

--- a/src/auksd/aukspriv
+++ b/src/auksd/aukspriv
@@ -38,6 +38,8 @@
 #                            default value is local3.notice
 #                            a "none" value means logs on stdout
 #
+#  AUKS_KINIT_OPTS         : additional options for the kinit command.
+#
 #----------------------------------------------------------------------------
 # Copyright  CEA/DAM/DIF (2009)
 #
@@ -115,9 +117,9 @@ function mylogger {
 
     if [[ ${AUKS_PRIV_SYSLOG_PRIO} == "none" ]]
 	then
-	echo "$(date) [INFO1] aukspriv: " $@
+	echo "$(date) [INFO1] aukspriv: " "$@"
     else
-	logger -i -p ${AUKS_PRIV_SYSLOG_PRIO} -t "aukspriv" $@
+	logger -i -p "${AUKS_PRIV_SYSLOG_PRIO}" -t "aukspriv" "$@"
     fi
 
 }
@@ -171,10 +173,16 @@ fi
 timeout_cmd=timeout
 kinit_cmd=kinit
 LOGGER=mylogger
+myname=$(basename "$0")
+aukspriv_cmd="${timeout_cmd} -s9 ${AUKS_PRIV_KINIT_TIMEOUT} ${kinit_cmd}\
+              -l ${AUKS_PRIV_LIFETIME}\
+              -kt ${AUKS_PRIV_KEYTAB}
+              ${AUKS_KINIT_OPTS}"
+
 #-------------------------------------------------------------------------------
 if [[ $1 == "-h" ]]
     then
-    echo -e "Usage: $(basename $0) [-h|-v]\n\n\
+    echo -e "Usage: ${myname} [-h|-v]\n\n\
 	\t-h\t\tprint this message\n\
 	\t-v\t\tlog on stdout instead of syslog\n"
     exit 0
@@ -186,10 +194,13 @@ else
     if [[ ${AUKS_PRIV_DONE} != "yes" ]]
 	then
 	export AUKS_PRIV_DONE=yes
+	# shellcheck disable=SC2068
 	$0 $@ >/dev/null 2>&1 &
 	exit 0
     fi
 fi
+
+
 if [[ -n ${AUKS_PRIV_USER} ]] && \
     [[ -n ${AUKS_PRIV_KEYTAB} ]] && \
     [[ -n ${AUKS_PRIV_PRINC} ]] && \
@@ -198,12 +209,11 @@ if [[ -n ${AUKS_PRIV_USER} ]] && \
     [[ -n ${AUKS_PRIV_KINIT_TIMEOUT} ]]
     then
 
-    while [ 1 -eq 1 ]
+    while true
       do
       if [[ ${AUKS_PRIV_USER} == "root" ]]; then
 	  # If we're targeting the root user, that's easy stuff.
-	  ERROR=$(${timeout_cmd} -s9 ${AUKS_PRIV_KINIT_TIMEOUT} ${kinit_cmd} -l ${AUKS_PRIV_LIFETIME} \
-	      -kt ${AUKS_PRIV_KEYTAB} ${AUKS_PRIV_PRINC} 2>&1 >/dev/null)
+	  ERROR=$(${aukspriv_cmd} "${AUKS_PRIV_PRINC}" 2>&1 >/dev/null)
 	  ERR_CODE=$?
       else
 	  # If we're not targetting the root user, we must change out identity.
@@ -214,14 +224,12 @@ if [[ -n ${AUKS_PRIV_USER} ]] && \
 	      ${LOGGER} "The keytab (${AUKS_PRIV_KEYTAB}) is not readable by the ${AUKS_PRIV_USER} user. \
                          Using ${fallback_ccache} as the credential cache"
 
-	      ERROR=$(${timeout_cmd} -s9 ${AUKS_PRIV_KINIT_TIMEOUT} ${kinit_cmd} -l ${AUKS_PRIV_LIFETIME} -c ${fallback_ccache} \
-		  -kt ${AUKS_PRIV_KEYTAB} ${AUKS_PRIV_PRINC} 2>&1 >/dev/null)
+	      ERROR=$(${aukspriv_cmd} -c "${fallback_ccache}" "${AUKS_PRIV_PRINC}" 2>&1 >/dev/null)
 	      ERR_CODE=$?
-	      chown ${AUKS_PRIV_USER}: ${fallback_ccache}
-	      chown 0600 ${fallback_ccache}
+	      chown "${AUKS_PRIV_USER}": "${fallback_ccache}"
+	      chown 0600 "${fallback_ccache}"
 	  else
-	      ERROR=$(su -c "${timeout_cmd} -s9 ${AUKS_PRIV_KINIT_TIMEOUT} ${kinit_cmd} -l ${AUKS_PRIV_LIFETIME} \
-	      -kt ${AUKS_PRIV_KEYTAB} ${AUKS_PRIV_PRINC}" ${AUKS_PRIV_USER} 2>&1 >/dev/null)
+	      ERROR=$(su -c "${aukspriv_cmd}" "${AUKS_PRIV_USER}" 2>&1 >/dev/null)
 	      ERR_CODE=$?
 	  fi
 

--- a/src/plugins/slurm/slurm-spank-auks.c
+++ b/src/plugins/slurm/slurm-spank-auks.c
@@ -93,6 +93,7 @@
 
 #include "auks/auks_error.h"
 #include "auks/auks_api.h"
+#include "auks/auks_krb5_cred.h"
 
 #define AUKS_HEADER "spank-auks: "
 
@@ -114,8 +115,7 @@
  */
 SPANK_PLUGIN(auks, 1);
 
-#define CREDCACHE_MAXLENGTH 128
-static char auks_credcache[CREDCACHE_MAXLENGTH];
+static char *auks_credcache = NULL;
 
 static char* auks_conf_file = NULL;
 static char* auks_sync_mode = NULL;
@@ -427,6 +427,8 @@ spank_auks_remote_init (spank_t sp, int ac, char *av[])
 
 	int mode;
 
+	auks_cred_t cred;
+
 	/* get required auks mode */
 	mode = _spank_auks_get_current_mode(sp,ac,av);
 	switch(mode) {
@@ -445,8 +447,8 @@ spank_auks_remote_init (spank_t sp, int ac, char *av[])
 		break;
 	}
 
-	/* set default auks cred cache length to 0 */
-	auks_credcache[0]='\0';
+	/* Reset auks credcache */
+	auks_credcache = NULL;
 
 	/* get slurm jobid */
 	if (spank_get_item (sp, S_JOB_ID, &jobid) != ESPANK_SUCCESS) {
@@ -464,27 +466,6 @@ spank_auks_remote_init (spank_t sp, int ac, char *av[])
 		return (-1);
 	}
 
-	/* build credential cache name */
-	fstatus = snprintf(auks_credcache,CREDCACHE_MAXLENGTH,
-			   "/tmp/krb5cc_%u_%u_XXXXXX",
-			   uid,jobid);
-	if ( fstatus >= CREDCACHE_MAXLENGTH ||
-	     fstatus < 0 ) {
-		xerror("unable to build auks credcache name");
-		goto exit;
-	}
-
-	/* build unique credential cache */
-	omask = umask(S_IRUSR | S_IWUSR);
-	fstatus = mkstemp(auks_credcache);
-	umask(omask);
-	if ( fstatus == -1 ) {
-		xerror("unable to create a unique auks credcache");
-		goto exit;
-	}
-	else
-		close(fstatus);
-
 	/* force KRB5CCNAME's value if the user wants so */
 	if (auks_hostcredcache_file != NULL) {
 		char *p = getenv("KRB5CCNAME");
@@ -501,53 +482,76 @@ spank_auks_remote_init (spank_t sp, int ac, char *av[])
 		goto exit;
 	}
 
-	/* get user credential */
-	fstatus = auks_api_get_cred(&engine,uid,auks_credcache);
+	/* Get auks cred */
+	fstatus = auks_api_get_auks_cred(&engine,uid,&cred);
+	if( fstatus ) {
+		xerror("unable to unpack auks cred from reply : %s",
+		       auks_strerror(fstatus));
+		fstatus = AUKS_ERROR_API_CORRUPTED_REPLY ;
+		goto unload;
+	}
+
+	/* change to user uid and gid before getting cred */
+	if ( setegid(gid) ) {
+		xerror("unable to switch to user gid : %s",
+		       strerror(errno));
+		goto out_cred;
+	}
+
+	if ( seteuid(uid) ) {
+		xerror("unable to switch to user uid : %s",
+		       strerror(errno));
+		goto out_cred;
+	}
+
+	fstatus = auks_krb_cc_new_unique(&auks_credcache);
+	if (fstatus) {
+	        xerror("Error while initializing a new unique");
+		goto out_err;
+	}
+
+	xinfo("Initialized ccache %s", auks_credcache);
+
+        /* Store user credential */
+	fstatus = auks_cred_store(&cred, auks_credcache);
 	if ( fstatus != AUKS_SUCCESS ) {
-		xerror("unable to get user %u cred : %s",uid,
-		      auks_strerror(fstatus));
-		unlink(auks_credcache);
-		auks_credcache[0]='\0';
-		goto unload;
-	}
-	xinfo("user '%u' cred stored in %s",uid,auks_credcache);
-
-	/* change file owner */
-	fstatus = chown(auks_credcache,uid,gid);
-	if ( fstatus != 0 ) {
-		xerror("unable to change cred %s owner : %s",
-		      auks_credcache,strerror(errno));
-		goto unload;
+		xerror("unable to store cred : %s",
+		       auks_strerror(fstatus));
+		fstatus = AUKS_ERROR_API_REPLY_PROCESSING ;
+		goto out_err;
 	}
 
-	/* set cred cache name in user env */
-	fstatus = spank_setenv(sp,"KRB5CCNAME",auks_credcache,1);
-	if ( fstatus != 0 ) {
-		xerror("unable to set KRB5CCNAME env var");
-	}
+	xinfo("user '%u' cred stored in ccache %s",uid, auks_credcache);
 
-	/* remove forced KRB5CCNAME's value if necessary */
-	if (auks_hostcredcache_file != NULL) {
-		if ( prev_krb5ccname != NULL ) {
-			setenv("KRB5CCNAME",prev_krb5ccname,1);
-			free(prev_krb5ccname);
-		} else {
-			unsetenv("KRB5CCNAME");
-		}
-	}
-
-	/* if required by the configuration, also put the cred cache name */
-	/* in the spank plugstack environment */
 	if ( auks_spankstack ) {
 		setenv("KRB5CCNAME",auks_credcache,1);
 	}
 
-unload:
+	/* Set KRBCCNAME in user env */
+	fstatus = spank_setenv(sp,"KRB5CCNAME",auks_credcache,1);
+	if ( fstatus != 0 )
+		xerror("unable to set KRB5CCNAME env var");
+
+ out_cred:
+	/* Free auks cred */
+	auks_cred_free_contents(&cred);
+
+ unload:
+	/* reset privileged uid/gid */
+	seteuid(getuid());
+	setegid(getgid());
+
 	/* unload auks conf */
 	auks_api_close(&engine);
 
 exit:
 	return (fstatus);
+
+out_err:
+	if (auks_credcache != NULL)
+	  free(auks_credcache);
+
+	goto out_cred;
 }
 
 /* remove cred at end of step */
@@ -567,37 +571,42 @@ spank_auks_remote_exit (spank_t sp, int ac, char **av)
 	if ( auks_hostcredcache_file != NULL )
 		free(auks_hostcredcache_file);
 
-	/* now only process in remote mode */
-	if (!spank_remote (sp))
-		return (0);
-
 	/* only process if a cred file was defined in a previous call */
-	if ( strnlen(auks_credcache,CREDCACHE_MAXLENGTH) == 0 )
+	if ( auks_credcache == NULL )
 		return 0;
 
-	/* get slurm job user uid & gid */
+	/* now only process in remote mode */
+	if (!spank_remote (sp)) {
+	        fstatus = 0;
+		goto out;
+	}
+
+        /* get slurm job user uid & gid */
 	if (spank_get_item (sp, S_JOB_UID, &uid) != ESPANK_SUCCESS) {
 		xerror("failed to get uid: %s", strerror(errno));
-		return (-1);
+		fstatus = -1;
+		goto out;
 	}
 	if (spank_get_item (sp, S_JOB_GID, &gid) != ESPANK_SUCCESS) {
 		xerror("failed to get gid: %s", strerror(errno));
-		return (-1);
+		fstatus = -1;
+		goto out;;
 	}
 
 	/* change to user gid before removing cred */
 	if ( setegid(gid) ) {
 		xerror("unable to switch to user gid : %s",
 		      strerror(errno));
-		return (-1);
+		fstatus = -1;
+		goto out;
 	}
 
 	/* change to user uid and gid before removing cred */
 	if ( seteuid(uid) ) {
 		xerror("unable to switch to user uid : %s",
 		      strerror(errno));
-		setegid(getgid());
-		return (-1);
+		fstatus = -1;
+		goto out;
 	}
 
 	/* sync all/some file systems to ensure dirty pages flush
@@ -605,14 +614,18 @@ spank_auks_remote_exit (spank_t sp, int ac, char **av)
 	   (see _sync_fs method for more details) */
 	_sync_fs();
 
-	/* remove credential cache */
-	fstatus = unlink(auks_credcache);
-	if ( fstatus != 0 ) {
-		xerror("unable to remove user '%u' cred cache %s : %s",
-		      uid,auks_credcache,strerror(errno));
+	/* Destroy all krb5 ccache */
+	fstatus = auks_krb_cc_destroy(auks_credcache);
+	if (fstatus) {
+	      xerror("Unable to destroy ccache %s",auks_credcache);
+	      goto out;
 	}
-	else
-		xinfo("user '%u' cred cache %s removed",uid,auks_credcache);
+
+        xinfo("Destroyed ccache %s", auks_credcache);
+
+out:
+	free(auks_credcache);
+	auks_credcache = NULL;
 
 	/* replace privileged uid/gid */
 	seteuid(getuid());
@@ -622,7 +635,7 @@ spank_auks_remote_exit (spank_t sp, int ac, char **av)
 	if ( auks_sync_mode != NULL )
 		free(auks_sync_mode);
 
-	return 0;
+	return fstatus;
 }
 
 


### PR DESCRIPTION
This patchset is about making auks agnostic to the underlying ccache type. This touches different parts of auks:
* The auks C API by adding some helper function for ccache management (generation/destruction)
* Aukspriv should not directly manage ccaches, instead it now relies on kinit to do the job
* The Spank plugin, same as aukspriv, it should not directly manage ccaches but only use the api

Fixes #11
May fix #23 