### PR TITLE
Add missing sections in manpages titles

### DIFF
--- a/doc/man/man1/auks.1
+++ b/doc/man/man1/auks.1
@@ -1,4 +1,4 @@
-.TH "auks" "March 2009" "Matthieu Hautreux" "auks"
+.TH "auks" "1" "March 2009" "Matthieu Hautreux" "auks"
 
 .SH "NAME"
 auks \- client program to manage AUKS credentials

--- a/doc/man/man5/auks.acl.5
+++ b/doc/man/man5/auks.acl.5
@@ -1,4 +1,4 @@
-.TH "auks.acl" "March 2009" "Matthieu Hautreux" "auks.acl"
+.TH "auks.acl" "5" "March 2009" "Matthieu Hautreux" "auks.acl"
 
 
 .SH "NAME"

--- a/doc/man/man5/auks.conf.5
+++ b/doc/man/man5/auks.conf.5
@@ -1,4 +1,4 @@
-.TH "auks.conf" "March 2009" "Matthieu Hautreux" "auks.conf"
+.TH "auks.conf" "5" "March 2009" "Matthieu Hautreux" "auks.conf"
 
 
 .SH "NAME"

--- a/doc/man/man8/auksd.8
+++ b/doc/man/man8/auksd.8
@@ -1,4 +1,4 @@
-.TH "auksd" "March 2009" "Matthieu Hautreux" "auksd"
+.TH "auksd" "8" "March 2009" "Matthieu Hautreux" "auksd"
 
 .SH "NAME"
 auksd \- AUKS daemon serves add/get/remove/dump AUKS client requests

--- a/doc/man/man8/auksdrenewer.8
+++ b/doc/man/man8/auksdrenewer.8
@@ -1,4 +1,4 @@
-.TH "auksdrenewer" "March 2009" "Matthieu Hautreux" "auksdrenewer"
+.TH "auksdrenewer" "8" "March 2009" "Matthieu Hautreux" "auksdrenewer"
 
 .SH "NAME"
 auksdrenewer \- AUKS daemon that handles AUKS credentials renewal

--- a/doc/man/man8/aukspriv.8
+++ b/doc/man/man8/aukspriv.8
@@ -1,4 +1,4 @@
-.TH "aukspriv" "March 2009" "Matthieu Hautreux" "aukspriv"
+.TH "aukspriv" "8" "March 2009" "Matthieu Hautreux" "aukspriv"
 
 .SH "NAME"
 aukspriv \- AUKS daemon that handles periodical Keytab to TGT operations


### PR DESCRIPTION
According to man-pages(7), the second field of the .TH line must be the
section number of the manpage. This commit adds the missing section
number in all AUKS manpages.