### PR TITLE
Fix AM_PROG_AR/AC_PROF_LIBTOOL macro ordering

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,9 +17,9 @@ dnl Autoconf header file to generate
 AC_CONFIG_HEADERS([config.h])
 
 dnl In order to build lib using Autotools .la format
+AM_PROG_AR
 AC_PROG_LIBTOOL
 m4_pattern_allow([AM_PROG_AR])
-AM_PROG_AR
 
 dnl This is a C project
 AC_PROG_CC


### PR DESCRIPTION
This commit re-orders AM_PROG_AR and AC_PROG_LIBTOOL macros in
configure.ac to avoid the following warning with autoreconf:

  configure.ac:22: warning: LT_INIT was called before AM_PROG_AR
  /usr/share/aclocal-1.14/ar-lib.m4:13: AM_PROG_AR is expanded from...
  configure.ac:22: the top level
  configure.ac:22: warning: AC_PROG_LIBTOOL was called before AM_PROG_AR
  /usr/share/aclocal-1.14/ar-lib.m4:13: AM_PROG_AR is expanded from...
  configure.ac:22: the top level
  configure.ac:22: warning: LT_INIT was called before AM_PROG_AR
  /usr/share/aclocal-1.14/ar-lib.m4:13: AM_PROG_AR is expanded from...
  configure.ac:22: the top level
  configure.ac:22: warning: AC_PROG_LIBTOOL was called before AM_PROG_AR
  /usr/share/aclocal-1.14/ar-lib.m4:13: AM_PROG_AR is expanded from...
  configure.ac:22: the top level
  configure.ac:22: warning: LT_INIT was called before AM_PROG_AR
  aclocal.m4:8672: AM_PROG_AR is expanded from...
  configure.ac:22: the top level
  configure.ac:22: warning: AC_PROG_LIBTOOL was called before AM_PROG_AR
  aclocal.m4:8672: AM_PROG_AR is expanded from...
  configure.ac:22: the top level