### PR TITLE
Add support for a HelperScript option

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -463,3 +463,17 @@ in mind, so it is better to describe the set up with 3 nodes.
     srun: error: compute: task 0: Exited with exit code 1
     $ 
 
+> Integration with AFS, EOS, $thing
+
+Filesystems (or other components) may want to leverage kerberos credentials for access, but it is often necessary to carry out additional steps in order to obtain the right authentication tokens.
+For instance, for AFS access, running `aklog` (or equivalent) is necessary to obtain AFS authentication tokens. CERN's EOS needs to generate similar auth tokens with `eosfusebind`, etc.
+Auks provides the option to run a user-provided helper script that runs the desired additional steps.
+
+This helper script will be called:
+
+1. After plugin initialisation, right after obtaining a valid kerberos ticket.
+
+2. Each time credential renewal has taken place.
+
+To use this feature, add a `HelperScript` key in the api section of the auks config (at least for the workernodes where renewal is happening) pointing to an executable to be run as described above.
+This executable will be run as the user who submitted the Slurm job.

--- a/doc/man/man5/auks.conf.5
+++ b/doc/man/man5/auks.conf.5
@@ -126,7 +126,12 @@ The default is \fB/dev/stdout\fR.
 \fBDebugLevel\fR
 specifies the level of debug to use. The default is \fB0\fR which 
 means no debug message.
-
+.TP
+\fBHelperScript\fR
+optional path to an executable to run during renewal and first cred get operations.
+This executable will have the corresponding KRB5CCNAME environment variable set
+to enable kerberos integration with other systems (e.g. to run aklog for AFS).
+.TP
 
 .SH "AUKSD CONFIGURATION"
 .LP

--- a/src/api/auks/auks_api.h
+++ b/src/api/auks/auks_api.h
@@ -272,6 +272,20 @@ int
 auks_api_dump_unpack(auks_message_t* msg,auks_cred_t** pcreds,int* pcreds_nb);
 
 /*!
+ * \brief Run helper script as user
+ *
+ * \param helper_script path to the script to be exec'ed
+ * \param auks_credcache ccache credential file to set for helper_script
+ * \param uid user uid to drop privileges to
+ * \param gid user gid to drop privileges to
+ *
+ * \retval AUKS_SUCCESS
+ * \retval AUKS_ERROR
+ */
+int
+auks_api_run_helper(char *helper_script, char *auks_credcache, uid_t uid, gid_t gid);
+
+/*!
  * @}
 */
 #endif

--- a/src/api/auks/auks_engine.c
+++ b/src/api/auks/auks_engine.c
@@ -168,7 +168,8 @@ auks_engine_init(auks_engine_t * engine,
 		 char* renewer_logfile,int renewer_loglevel,
 		 char* renewer_debugfile,int renewer_debuglevel,
 		 time_t renewer_delay,
-		 time_t renewer_minlifetime)
+		 time_t renewer_minlifetime,
+		 char *helper_script)
 {
 	int fstatus = AUKS_ERROR ;
 
@@ -228,6 +229,7 @@ auks_engine_init(auks_engine_t * engine,
 	engine->renewer_delay = renewer_delay;
 	engine->renewer_minlifetime = renewer_minlifetime;
 
+	init_strdup(engine->helper_script, helper_script);
 
 	if (engine->primary_hostname == NULL ||
 	    engine->primary_address == NULL ||
@@ -388,6 +390,8 @@ auks_engine_init_from_config_file(auks_engine_t * engine, char *conf_file)
 	char *delay_str;
 	char *nat_str;
 	
+	char *helper_script;
+
 	long int ll, dl, rnb, timeout, delay;
 
 	char *renewer_lfile;
@@ -575,6 +579,11 @@ auks_engine_init_from_config_file(auks_engine_t * engine, char *conf_file)
 		if (dl == LONG_MIN || dl == LONG_MAX)
 			dl = DEFAULT_AUKS_DEBUGLEVEL;
 
+		/* read helper script value */
+		helper_script = config_GetKeyValueByName(config, i, "HelperScript");
+		if (helper_script == NULL)
+			helper_script = DEFAULT_AUKS_HELPER_SCRIPT;
+
 		valid_block_nb++;
 
 	}
@@ -655,7 +664,8 @@ auks_engine_init_from_config_file(auks_engine_t * engine, char *conf_file)
 					   rnb,timeout,delay,nat,
 					   renewer_lfile,renewer_ll,
 					   renewer_dfile,renewer_dl,
-					   renewer_delay,renewer_minlifetime);
+					   renewer_delay,renewer_minlifetime,
+					   helper_script);
 		
 	}
 	

--- a/src/api/auks/auks_engine.h
+++ b/src/api/auks/auks_engine.h
@@ -115,6 +115,7 @@
 #define DEFAULT_AUKSD_LOGLEVEL          1
 #define DEFAULT_AUKSD_DEBUGFILE         "/var/log/auksd.log"
 #define DEFAULT_AUKSD_DEBUGLEVEL        0
+#define DEFAULT_AUKS_HELPER_SCRIPT	NULL
 
 #define DEFAULT_AUKSD_THREADS_NB       10
 #define DEFAULT_AUKSD_QUEUE_SIZE       50
@@ -166,6 +167,7 @@ typedef struct auks_engine {
 	int retries;
 	time_t timeout;
 	time_t delay;
+	char *helper_script;
 
 	int nat_traversal;
 
@@ -226,6 +228,8 @@ typedef struct auks_engine {
  * \param renewer_minlifetime min lifetime for a cred to be renewed by the
  *        renewer
  *
+ * \param helper_script optional path to helper script to run during cred renewal
+ *
  * \retval AUKS_SUCCESS on success
  * \retval AUKS_ERROR on failure
  *  
@@ -247,7 +251,8 @@ auks_engine_init(auks_engine_t * engine,
 		 char* renewer_logfile,int renewer_loglevel,
 		 char* renewer_debugfile,int renewer_debuglevel,
 		 time_t renewer_delay,
-		 time_t renewer_minlifetime);
+		 time_t renewer_minlifetime,
+		 char *helper_script);
 
 /*!
  * \brief Initialize auks engine structure from a configuration file

--- a/src/plugins/slurm/slurm-spank-auks.c
+++ b/src/plugins/slurm/slurm-spank-auks.c
@@ -578,6 +578,9 @@ spank_auks_remote_init (spank_t sp, int ac, char *av[])
 	if ( fstatus != 0 )
 		xerror("unable to set KRB5CCNAME env var");
 
+	/* fire helper script for the first time */
+	auks_api_run_helper(engine.helper_script, auks_credcache, uid, gid);
+
  out_cred:
 	/* free auks cred */
 	auks_cred_free_contents(&cred);


### PR DESCRIPTION
This MR adds support for a HelperScript option in the `[api]` config section to be run at the first "auks cred get" and after each renewal.

This has been tested to work in a test environment just fine. Would like to send this out to get feedback on the approach/implementation. This is a feature that we're going to be running in a production environment with AFS and EOS soon, so I can give more info on how well this works in the near future, if there are such concerns. Long term we would like not have to patch auks to achieve this, of course :)

I think I've added the relevant bits of docs, headers and comments, but let me know if I've left anything out that should be in there as well.